### PR TITLE
Fix crash on unknown image read error

### DIFF
--- a/similar_img.py
+++ b/similar_img.py
@@ -610,6 +610,10 @@ if __name__ == "__main__":
                                     print('\x1b[0;35mProbably not an image.\x1b[0m\x1b[K')
                                 total_not_a_image += 1
                                 continue
+                            except:
+                                if args.verbose:
+                                    print('\x1b[0;35mUnexpected error:\x1b[0m', sys.exc_info()[0],'\x1b[K')
+                                continue
                         else:
                             try:
                                 dir_img_f_hash_diff, dir_img_f_hash_avg, write_once = diff_file(path, hash_cache_f, write_once, dir_path, False)
@@ -617,6 +621,10 @@ if __name__ == "__main__":
                                 if args.verbose:
                                     print('\x1b[0;35mProbably not an image.\x1b[0m\x1b[K')
                                 total_not_a_image += 1
+                                continue
+                            except:
+                                if args.verbose:
+                                    print('\x1b[0;35mUnexpected error:\x1b[0m', sys.exc_info()[0],'\x1b[K')
                                 continue
 
                         if share_print(img_f_hash_diff, img_f_hash_avg, dir_img_f_hash_diff, dir_img_f_hash_avg, path, ei, total_matched):


### PR DESCRIPTION
First, thank you for your script.

This is just a minor "fix", that prevents script from crashing on unhandled exception. The script doesn't search further.

```bash
python3 ~/Projects/find_similar_image/similar_img.py -d /usr/share -l matches /tmp/Screenshot\ at\ 2020-06-07\ 16-53-03.png
---
Traceback (most recent call last):
  File "/home/jezek/Projects/find_similar_image/similar_img.py", line 603, in <module>
    dir_img_f_hash_diff, dir_img_f_hash_avg, write_once = diff_file(path, hash_cache_f, write_once, dir_path, False)
  File "/home/jezek/Projects/find_similar_image/similar_img.py", line 203, in diff_file
    dir_img_f_hash_diff = DifferenceHash(dir_img_f)
  File "/home/jezek/Projects/find_similar_image/similar_img.py", line 119, in DifferenceHash
    theImage = theImage.convert("L")  # 8-bit grayscale #orig
  File "/usr/lib/python3/dist-packages/PIL/Image.py", line 873, in convert
    self.load()
  File "/usr/lib/python3/dist-packages/PIL/GbrImagePlugin.py", line 88, in load
    self.frombytes(self.fp.read(self._data_size))
  File "/usr/lib/python3/dist-packages/PIL/Image.py", line 772, in frombytes
    raise ValueError("not enough image data")
ValueError: not enough image data
```

The solution is just to print the error (if verbose mode) and continue to another image. Maybe there is more proper solution, this one was the easiest for me.